### PR TITLE
add plugin query example MOB-22157

### DIFF
--- a/src/pages/usage/index.md
+++ b/src/pages/usage/index.md
@@ -12,7 +12,7 @@ cURL command examples for queries/mutations
 
 ### Read Sessions
 
-```
+```text
 curl 'https://graffias.adobe.io/graffias/graphql' \
   -H 'Content-Type: application/json' \
   -H 'x-gw-ims-org-id: [Organization ID]@Adobe.Org' \
@@ -23,7 +23,7 @@ curl 'https://graffias.adobe.io/graffias/graphql' \
 
 ### Read Session Annotations
 
-```
+```text
 curl 'https://graffias.adobe.io/graffias/graphql' \
   -H 'Content-Type: application/json' \
   -H 'x-gw-ims-org-id: [Organization ID]@Adobe.Org' \
@@ -34,7 +34,7 @@ curl 'https://graffias.adobe.io/graffias/graphql' \
 
 ### Read Events
 
-```
+```text
 curl 'https://graffias.adobe.io/graffias/graphql' \
   -H 'Content-Type: application/json' \
   -H 'x-gw-ims-org-id: [Organization ID]@Adobe.Org' \
@@ -45,7 +45,7 @@ curl 'https://graffias.adobe.io/graffias/graphql' \
 
 ### Read Events with Annotations
 
-```
+```text
 curl 'https://graffias.adobe.io/graffias/graphql' \
   -H 'Content-Type: application/json' \
   -H 'x-gw-ims-org-id: [Organization ID]@Adobe.Org' \
@@ -56,7 +56,7 @@ curl 'https://graffias.adobe.io/graffias/graphql' \
 
 ### Read Plugins
 
-```
+```text
 curl 'https://graffias.adobe.io/graffias/graphql' \
   -H 'Content-Type: application/json' \
   -H 'x-gw-ims-org-id: [Organization ID]@Adobe.Org' \
@@ -69,7 +69,7 @@ curl 'https://graffias.adobe.io/graffias/graphql' \
 
 ### Create a Session
 
-```
+```text
 curl 'https://graffias.adobe.io/graffias/graphql' \
   -H 'Content-Type: application/json' \
   -H 'x-gw-ims-org-id: [Organization ID]@Adobe.Org' \
@@ -80,7 +80,7 @@ curl 'https://graffias.adobe.io/graffias/graphql' \
 
 ### Update a Session
 
-```
+```text
 curl 'https://graffias.adobe.io/graffias/graphql' \
   -H 'Content-Type: application/json' \
   -H 'x-gw-ims-org-id: [Organization ID]@Adobe.Org' \
@@ -91,7 +91,7 @@ curl 'https://graffias.adobe.io/graffias/graphql' \
 
 ### Delete a Session
 
-```
+```text
 curl 'https://graffias.adobe.io/graffias/graphql' \
   -H 'Content-Type: application/json' \
   -H 'x-gw-ims-org-id: [Organization ID]@Adobe.Org' \

--- a/src/pages/usage/index.md
+++ b/src/pages/usage/index.md
@@ -54,6 +54,17 @@ curl 'https://graffias.adobe.io/graffias/graphql' \
   --data-binary '{"query":"query {  events(sessionUuid:\"[session UUID]\",_page:0,_size:50){ uuid clientId timestamp vendor type payload annotations { namespace payload }}}"}'
 ```
 
+### Read Plugins
+
+```
+curl 'https://graffias.adobe.io/graffias/graphql' \
+  -H 'Content-Type: application/json' \
+  -H 'x-gw-ims-org-id: [Organization ID]@Adobe.Org' \
+  -H 'x-api-key: [Client ID]' \
+  -H 'Authorization: Bearer [Access Token]' \
+  --data-binary '{"query":"query {  plugins { uuid, namespace, updatedTsAfter, updatedTsBefore, displayName, type } }"}'
+```
+
 ## Mutations
 
 ### Create a Session


### PR DESCRIPTION
Showing users how to query for plugins.

## Description

Public API users have access to query their Adobe Assurance plugins. Adding an example.

MOB-22157

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
